### PR TITLE
Add 3 seconds delay to take a picture

### DIFF
--- a/code/finished_allseeingpi.py
+++ b/code/finished_allseeingpi.py
@@ -4,6 +4,7 @@ from overlay_functions import *
 from time import gmtime, strftime
 from guizero import App, PushButton, Text, Picture
 from twython import Twython
+import time
 from auth import (
     consumer_key,
     consumer_secret,
@@ -21,6 +22,7 @@ def next_overlay():
 def take_picture():
     global output
     output = strftime("/home/pi/allseeingpi/image-%d-%m %H:%M.png", gmtime())
+    time.sleep(3) # sleep for 3 seconds so you can be prepared to get a better picture
     camera.capture(output)
     camera.stop_preview()
     remove_overlays(camera)


### PR DESCRIPTION
When you press the button to take a picture, the booth can shake and ruin your photo.
Adding a 3 second delay before the photo will help to get better pictures, and also allows you to be prepared and walk a little away from the booth, or set the overlay properly.